### PR TITLE
157931480 API finish up on request create endpoint

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -45,14 +45,20 @@ def create_app(config_name):
                 return response
             
             request_obj = Request(title, description, category)
-            result = request_obj.save(1)
+            results = request_obj.save(1)
             
-            if result[0] == "1":
+            if results[0] == "1":
+                result = results[1].get(title)
                 response = jsonify({
                     'message': "Maintenance request submitted successfully.",
+                    'request_id': result[0],
                     'title': title,
-                    'description': description,
-                    'category': category,
+                    'description': result[1],
+                    'type': result[2],
+                    'status': result[4],
+                    'user_id': result[3],
+                    'created_at': result[5],
+                    'updated_at': result[6],
                 })
                 response.status_code = 201
             else:

--- a/api/app/models.py
+++ b/api/app/models.py
@@ -8,7 +8,6 @@ requests = {}
 
 class Request():
     """ the requests model """
-    user_requests = {}
 
     def __init__(self, title, description, category):
         """initialize instance variables """
@@ -17,6 +16,7 @@ class Request():
         self.category = category
         self.status = "open"
         self.created_at = time.strftime('%A %B, %d %Y %H:%M:%S')
+        self.updated_at = self.created_at
     
     def save(self, user_id):
         """ save request """
@@ -25,8 +25,9 @@ class Request():
         count = 0
         for user, user_requests in requests.iteritems():
             count += len(user_requests)
-        new_request = ({self.title: (self.description, self.category,user_id, 
-                                      self.status, self.created_at)})
+        new_request = ({self.title: (count+1, self.description, self.category,
+                                    user_id, self.status, self.created_at, 
+                                    self.updated_at)})
         if my_requests != "0":
             """check if request already exists """
             is_exist = my_requests.get(self.title, "0")


### PR DESCRIPTION
### What does this PR do?
Allows a user to create a request.

### Description of Task to be completed?
Create request where:
- title, description and type fields must not be null
- new title cannot belong to a request that already exists

How should this be manually tested?
Clone repo:
``` $ git clone https://github.com/johnmusiu/Maintenance-Tracker/tree/ft-api-user-create-request-157931480```
Cd into repo:
```$ cd Maintenace-Tracker```
Create a virtual environment:
```$ virtualenv venv```
Activate a virtual environment:
```$ source venv/bin/activate```
Run app:
```export FLASK_APP="run.py"```
```export APP_SETTINGS="development"```
```$ python run.py```
```$ pip install -r requirements.txt```

_Test the endpoint on postman:_
Create a request on the endpoint `127.0.0.1:5000/api/v1/users/requests` (**POST**) such as

```{ "title": "", "description": "replace the keyboards", "type":"maintenance"}```

Also try testing by nullifying any of the above fields to test the app further.

Run tests: 
```$ pytest ``` 


### Any background context you want to provide?
Data is stored using a combination of a dictionary and lists.

What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/157931480

### Screenshots:
#### Create request:
![image](https://user-images.githubusercontent.com/12577659/40780855-8bd0912c-64e2-11e8-93c9-796e78f64935.png)

#### Create request with null field:
![image](https://user-images.githubusercontent.com/12577659/40780906-b4303b18-64e2-11e8-8fe3-865cfee6e897.png)


#### Create already existing title
![image](https://user-images.githubusercontent.com/12577659/40780879-9c8d1364-64e2-11e8-8573-40871998fe94.png)


